### PR TITLE
[PUBDEV-7496] revert previous renaming of getWeight

### DIFF
--- a/h2o-tree-api/src/main/java/ai/h2o/algos/tree/INodeStat.java
+++ b/h2o-tree-api/src/main/java/ai/h2o/algos/tree/INodeStat.java
@@ -2,12 +2,6 @@ package ai.h2o.algos.tree;
 
 public interface INodeStat {
 
-  float getGain();
-
-  float getCover();
-
-  float getBaseWeight();
-
-  int getLeafCount();
+  float getWeight();
 
 }

--- a/xgboost-predictor/src/main/java/biz/k11i/xgboost/tree/RegTreeNodeStat.java
+++ b/xgboost-predictor/src/main/java/biz/k11i/xgboost/tree/RegTreeNodeStat.java
@@ -23,10 +23,14 @@ public class RegTreeNodeStat implements INodeStat, Serializable {
         leaf_child_cnt = reader.readInt();
     }
 
+    @Override
+    public float getWeight() {
+        return getCover();
+    }
+
     /**
      * @return loss chg caused by current split
      */
-    @Override
     public float getGain() {
         return loss_chg;
     }
@@ -34,7 +38,6 @@ public class RegTreeNodeStat implements INodeStat, Serializable {
     /**
      * @return sum of hessian values, used to measure coverage of data
      */
-    @Override
     public float getCover() {
         return sum_hess;
     }
@@ -42,7 +45,6 @@ public class RegTreeNodeStat implements INodeStat, Serializable {
     /**
      * @return weight of current node
      */
-    @Override
     public float getBaseWeight() {
         return base_weight;
     }
@@ -50,7 +52,6 @@ public class RegTreeNodeStat implements INodeStat, Serializable {
     /**
      * @return number of child that is leaf node known up to now
      */
-    @Override
     public int getLeafCount() {
         return leaf_child_cnt;
     }


### PR DESCRIPTION
INodeStat interface should not be changed because its used in SharedTreeNode and we cannot implement all the methods there