### PR TITLE
Add support for rank:ndcg and reg:logistic objectives.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ Xgboost-predictor-java is about **6,000 to 10,000 times faster than** xgboost4j 
     - "multi:softmax"
     - "multi:softprob"
     - "reg:linear"
+    - "reg:logistic"
     - "rank:pairwise"
+    - "rank: ndcg"
 - API
     - Predicts probability or classification
         - `Predictor#predict(FVec)`

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Xgboost-predictor-java is about **6,000 to 10,000 times faster than** xgboost4j 
     - "reg:linear"
     - "reg:logistic"
     - "rank:pairwise"
-    - "rank: ndcg"
+    - "rank:ndcg"
 - API
     - Predicts probability or classification
         - `Predictor#predict(FVec)`

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,25 @@
 # Release notes
 
+## 0.3.18
+
+- Add support for `reg:logistic` and `rank:ndcg` oobjectives. [PR](https://github.com/h2oai/xgboost-predictor/pull/20)
+
+## 0.3.17
+
+- Revert renaming of getWeight. [PR](https://github.com/h2oai/xgboost-predictor/pull/19)
+
+## 0.3.16
+
+- Expose `RegTreeNode` stats. [PR](https://github.com/h2oai/xgboost-predictor/pull/18)
+
+## 0.3.15
+
+- Fix loading an empty gblinear booster [PR](https://github.com/h2oai/xgboost-predictor/pull/16)
+
+## 0.3.14
+
+- Upgrade to XGBoost v1.0.0 support. [PR1](https://github.com/h2oai/xgboost-predictor/pull/14), [PR2](https://github.com/h2oai/xgboost-predictor/pull/15)
+
 ## 0.3.0
 
 - [#27](https://github.com/komiya-atsushi/xgboost-predictor-java/pull/27) Support DART model.

--- a/xgboost-predictor/src/main/java/biz/k11i/xgboost/learner/ObjFunction.java
+++ b/xgboost-predictor/src/main/java/biz/k11i/xgboost/learner/ObjFunction.java
@@ -16,7 +16,9 @@ public class ObjFunction implements Serializable {
 
     static {
         register("rank:pairwise", new ObjFunction());
+        register("rank:ndcg", new ObjFunction());
         register("binary:logistic", new RegLossObjLogistic());
+        register("reg:logistic", new RegLossObjLogistic());
         register("binary:logitraw", new ObjFunction());
         register("multi:softmax", new SoftmaxMultiClassObjClassify());
         register("multi:softprob", new SoftmaxMultiClassObjProb());


### PR DESCRIPTION
Closes #17 as well as the `reg:logistic` objective.

I also took a best guess at backporting some of the release log entries for the last year or so.