### PR TITLE
Extend Predictor API to support iterative scoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,8 @@ subprojects {
         if (prop != "false" && !JavaVersion.current().isJava7()) {
             String message = "ERROR: Java 7 required but " +
                     JavaVersion.current() +
-                    " found. Change your JAVA_HOME environment variable."
+                    " found. Change your JAVA_HOME environment variable. " +
+                    "For local development, you can set environment variable CHECK_JAVA_VERSION=false to bypass the check."
             throw new IllegalStateException(message)
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # For building on Java 7 we need to explicitly enable TLSv1 (this is mainly for MOJO compatibility tests)
 systemProp.https.protocols=TLSv1,TLSv1.1,TLSv1.2
 
-version=0.3.18
+version=0.3.19
 localNexusLocation=http://nexus:8081/nexus/repository

--- a/xgboost-predictor/src/main/java/biz/k11i/xgboost/Predictor.java
+++ b/xgboost-predictor/src/main/java/biz/k11i/xgboost/Predictor.java
@@ -241,14 +241,34 @@ public class Predictor implements Serializable {
      * @return prediction value
      */
     public float predictSingle(FVec feat, boolean output_margin, int ntree_limit) {
-        float pred = predictSingleRaw(feat, ntree_limit);
+        float pred = predictSingleRaw(feat, base_score, ntree_limit);
         if (!output_margin) {
             pred = obj.predTransform(pred);
         }
         return pred;
     }
 
-    float predictSingleRaw(FVec feat, int ntree_limit) {
+    /**
+     * Generates a prediction for given feature vector, uses user-specified base-margin
+     * instead of model's base-score.
+     * <p>
+     * This method only works when the model outputs single value.
+     * </p>
+     *
+     * @param feat          feature vector
+     * @param base_margin   predict with base margin for each prediction
+     * @param output_margin whether to only predict margin value instead of transformed prediction
+     * @return prediction value
+     */
+    public float predictSingle(FVec feat, float base_margin, boolean output_margin) {
+        float pred = predictSingleRaw(feat, base_margin, 0);
+        if (!output_margin) {
+            pred = obj.predTransform(pred);
+        }
+        return pred;
+    }
+
+    float predictSingleRaw(FVec feat, float base_score, int ntree_limit) {
         return gbm.predictSingle(feat, ntree_limit) + base_score;
     }
 
@@ -347,8 +367,17 @@ public class Predictor implements Serializable {
         return name_obj;
     }
 
+    public ObjFunction getObjective() {
+        return obj;
+    }
+
     public float getBaseScore() {
         return base_score;
+    }
+
+    // for testing/development only
+    void setBaseScore(float base_score) {
+        this.base_score = base_score;
     }
 
 }

--- a/xgboost-predictor/src/main/java/biz/k11i/xgboost/gbm/GBTree.java
+++ b/xgboost-predictor/src/main/java/biz/k11i/xgboost/gbm/GBTree.java
@@ -24,7 +24,7 @@ public class GBTree extends GBBase {
 
         trees = new RegTree[mparam.num_trees];
         for (int i = 0; i < mparam.num_trees; i++) {
-            trees[i] = config.getRegTreeFactory().loadTree(reader);
+            trees[i] = config.getRegTreeFactory().loadTree(i, reader);
         }
 
         int[] tree_info = mparam.num_trees > 0 ? reader.readIntArray(mparam.num_trees) : new int[0];

--- a/xgboost-predictor/src/main/java/biz/k11i/xgboost/tree/DefaultRegTreeFactory.java
+++ b/xgboost-predictor/src/main/java/biz/k11i/xgboost/tree/DefaultRegTreeFactory.java
@@ -9,7 +9,7 @@ public final class DefaultRegTreeFactory implements RegTreeFactory {
   public static RegTreeFactory INSTANCE = new DefaultRegTreeFactory();
 
   @Override
-  public final RegTree loadTree(ModelReader reader) throws IOException {
+  public RegTree loadTree(int treeId, ModelReader reader) throws IOException {
     RegTreeImpl regTree = new RegTreeImpl();
     regTree.loadModel(reader);
     return regTree;

--- a/xgboost-predictor/src/main/java/biz/k11i/xgboost/tree/RegTreeFactory.java
+++ b/xgboost-predictor/src/main/java/biz/k11i/xgboost/tree/RegTreeFactory.java
@@ -6,6 +6,15 @@ import java.io.IOException;
 
 public interface RegTreeFactory {
 
-  RegTree loadTree(ModelReader reader) throws IOException;
+  /**
+   * Loads one tree stored at current position of the provided ModelReader.
+   * @param treeId tree index, this is a physical index of the tree in the serialized model. For multiclass models
+   *               trees are serialized in groups per-class, class 1 trees, class 2 trees, ... No assumptions can be
+   *               made how tree index translates to a particular tree of a given class.
+   * @param reader model reader
+   * @return instance of a regression tree
+   * @throws IOException when model is corrupted/cannot be deserialized
+   */
+  RegTree loadTree(int treeId, ModelReader reader) throws IOException;
 
 }

--- a/xgboost-predictor/src/test/java/biz/k11i/xgboost/PredictorTest.java
+++ b/xgboost-predictor/src/test/java/biz/k11i/xgboost/PredictorTest.java
@@ -1,0 +1,60 @@
+package biz.k11i.xgboost;
+
+import biz.k11i.xgboost.learner.ObjFunction;
+import biz.k11i.xgboost.util.FVec;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PredictorTest {
+
+    private Predictor predictor;
+    private FVec row;
+
+    @Before
+    public void setup() throws Exception {
+        predictor = new Predictor(getClass().getResourceAsStream("/boosterBytes.bin"));
+        float[] rowData = new float[] { 10, 20, 30, 5, 7, 10 };
+        row = FVec.Transformer.fromArray(rowData, false);
+
+    }
+
+    @Test
+    public void shouldPredictWithDefaultBaseScore() {
+        final float baseScoreOffset = 0.5f;
+        final float modelBaseScore = predictor.getBaseScore();
+
+        float defPrediction = predictor.predictSingle(row, true);
+        predictor.setBaseScore(modelBaseScore + baseScoreOffset);
+
+        float modPrediction = predictor.predictSingle(row, true);
+        assertEquals(baseScoreOffset, modPrediction - defPrediction, 0);
+    }
+
+    @Test
+    public void shouldIgnoreDefaultBaseScore() {
+        final float baseScoreOffset = 0.5f;
+        final float modelBaseScore = predictor.getBaseScore();
+
+        float defPrediction = predictor.predictSingle(row, true);
+        float custPrediction = predictor.predictSingle(row, modelBaseScore, true);
+        assertEquals(defPrediction, custPrediction, 0);
+
+        float actual = predictor.predictSingle(row, modelBaseScore + baseScoreOffset, true);
+        assertEquals(defPrediction + baseScoreOffset, actual, 0);
+    }
+
+    @Test
+    public void shouldReturnObjectiveFunction() {
+        final ObjFunction objFunction = predictor.getObjective();
+        assertNotNull(objFunction);
+
+        float expected = predictor.predictSingle(row);
+        float rawActual = predictor.predictSingle(row, true);
+        float actual = objFunction.predTransform(rawActual);
+
+        assertEquals(expected, actual, 0);
+    }
+
+}

--- a/xgboost-predictor/src/test/java/biz/k11i/xgboost/tree/CustomRegTreeFactoryTest.java
+++ b/xgboost-predictor/src/test/java/biz/k11i/xgboost/tree/CustomRegTreeFactoryTest.java
@@ -1,0 +1,37 @@
+package biz.k11i.xgboost.tree;
+
+import biz.k11i.xgboost.Predictor;
+import biz.k11i.xgboost.config.PredictorConfiguration;
+import biz.k11i.xgboost.util.ModelReader;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class CustomRegTreeFactoryTest {
+
+    @Test
+    public void shouldCallLoadTreeWithSequentialTreeIndices() throws IOException {
+        SpyingRegTreeFactory factory = new SpyingRegTreeFactory();
+        PredictorConfiguration pc = PredictorConfiguration.builder()
+                .regTreeFactory(factory)
+                .build();
+        Predictor p = new Predictor(getClass().getResourceAsStream("/boosterBytes.bin"), pc);
+        assertNotNull(p);
+
+        assertEquals(4, factory.lastTreeId);
+    }
+
+    private static class SpyingRegTreeFactory implements RegTreeFactory {
+        private int lastTreeId = -1;
+        @Override
+        public RegTree loadTree(int treeId, ModelReader reader) throws IOException {
+            assertEquals("Tree indices are not sequential", lastTreeId + 1, treeId);
+            lastTreeId = treeId;
+            return DefaultRegTreeFactory.INSTANCE.loadTree(treeId, reader);
+        }
+    }
+
+}


### PR DESCRIPTION
This changes is inteded to support PR https://github.com/h2oai/h2o-3/pull/6481

In the referenced PR we implement iterative XGBoost scoring.

Changes in this PR:
- provide tree index when model is deserialized from booster - this way we can skip trees we don't need (that were applied in prior scoring iterations)
- extend predictSingle API to allow predicting with a custom margin and outputing raw prediction (not transformed)
- expose objective function